### PR TITLE
Porepy updates in FractureNetwork and Exporter

### DIFF
--- a/src/pygeon/grids/graph.py
+++ b/src/pygeon/grids/graph.py
@@ -103,7 +103,7 @@ class Graph(pp.Grid):
         data_IJ = np.zeros(n)
 
         ind = 0
-        for (i_c, cycle) in enumerate(cb):
+        for i_c, cycle in enumerate(cb):
             for i in np.arange(len(cycle)):
                 start = cycle[i - 1]
                 stop = cycle[i]
@@ -133,8 +133,8 @@ class Graph(pp.Grid):
         Dummy tags for the peaks and ridges.
         """
 
-        self.tags["tip_ridges"] = np.zeros(self.num_ridges, dtype=np.bool)
-        self.tags["tip_peaks"] = np.zeros(self.num_peaks, dtype=np.bool)
+        self.tags["tip_ridges"] = np.zeros(self.num_ridges, dtype=bool)
+        self.tags["tip_peaks"] = np.zeros(self.num_peaks, dtype=bool)
 
     def tag_boundary(self):
         """
@@ -230,7 +230,7 @@ class Graph(pp.Grid):
         nsp = np.array(list(nsp), dtype=np.object)
 
         # remove from the not shortest paths variables the shortest paths variable
-        to_keep = np.ones(nsp.size, dtype=np.bool)
+        to_keep = np.ones(nsp.size, dtype=bool)
         for s in sp:
             for idx, ns in enumerate(nsp):
                 if np.array_equal(np.sort(s), np.sort(ns)):

--- a/tests/integration/test_differentials.py
+++ b/tests/integration/test_differentials.py
@@ -39,7 +39,7 @@ class DifferentialsTest(unittest.TestCase):
 
         bbox = {"xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1}
         domain = pp.Domain(bounding_box=bbox)
-        network = pp.FractureNetwork2d(fracs, domain)
+        network = pp.create_fracture_network(fracs, domain)
         mesh_kwargs = {"mesh_size_frac": 1, "mesh_size_min": 1}
 
         mdg = network.mesh(mesh_kwargs)

--- a/tests/unit/test_grid_ridges.py
+++ b/tests/unit/test_grid_ridges.py
@@ -99,7 +99,7 @@ class GridRidgesTest(unittest.TestCase):
 
             bbox = {"xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1}
             domain = pp.Domain(bounding_box=bbox)
-            network = pp.FractureNetwork2d(fracs, domain)
+            network = pp.create_fracture_network(fracs, domain)
             mesh_kwargs = {"mesh_size_frac": 1, "mesh_size_min": 1}
 
             return network.mesh(mesh_kwargs)
@@ -128,7 +128,7 @@ class GridRidgesTest(unittest.TestCase):
 
             bbox = {"xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1, "zmin": 0, "zmax": 1}
             domain = pp.Domain(bounding_box=bbox)
-            network = pp.FractureNetwork3d([f_1], domain=domain)
+            network = pp.create_fracture_network([f_1], domain=domain)
             mesh_args = {"mesh_size_frac": 1, "mesh_size_min": 1}
 
             return network.mesh(mesh_args)
@@ -169,7 +169,7 @@ class GridRidgesTest(unittest.TestCase):
 
             bbox = {"xmin": 0, "xmax": 1, "ymin": 0, "ymax": 1, "zmin": 0, "zmax": 1}
             domain = pp.Domain(bounding_box=bbox)
-            network = pp.FractureNetwork3d([f_1, f_2], domain=domain)
+            network = pp.create_fracture_network([f_1, f_2], domain=domain)
             mesh_args = {"mesh_size_frac": 1, "mesh_size_min": 1}
 
             return network.mesh(mesh_args)

--- a/tutorials/darcy.ipynb
+++ b/tutorials/darcy.ipynb
@@ -1,13 +1,14 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "essential-american",
    "metadata": {},
    "source": [
     "# Darcy equation\n",
     "\n",
-    "In this tutorial we present how to solve a Darcy equation with [PyGeoN](https://github.com/compgeo-mox/pygeon).  The unkwons are the velocity $q$ and the pressure $p$.\n",
+    "In this tutorial we present how to solve a Darcy equation with [PyGeoN](https://github.com/compgeo-mox/pygeon).  The unknowns are the velocity $q$ and the pressure $p$.\n",
     "\n",
     "Let $\\Omega=(0,1)^2$ with boundary $\\partial \\Omega$ and outward unit normal ${\\nu}$. Given \n",
     "$k$ the matrix permeability, we want to solve the following problem: find $({q}, p)$ such that\n",
@@ -38,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "id": "dietary-perth",
    "metadata": {},
    "outputs": [],
@@ -60,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 13,
    "id": "spectacular-saturn",
    "metadata": {},
    "outputs": [],
@@ -68,7 +69,11 @@
     "N = 10\n",
     "sd = pp.StructuredTriangleGrid([N] * 2, [1] * 2)\n",
     "# convert the grid into a mixed-dimensional grid\n",
-    "mdg = pp.meshing.subdomains_to_mdg([sd])"
+    "mdg = pg.as_mdg(sd)\n",
+    "\n",
+    "# Convert to a pygeon grid\n",
+    "pg.convert_from_pp(sd)\n",
+    "sd.compute_geometry()\n"
    ]
   },
   {
@@ -81,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "id": "spare-person",
    "metadata": {},
    "outputs": [],
@@ -113,6 +118,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "secure-flesh",
    "metadata": {},
@@ -121,7 +127,7 @@
     "$$\n",
     "\\left(\n",
     "\\begin{array}{cc} \n",
-    "M & B^\\top\\\\\n",
+    "M & -B^\\top\\\\\n",
     "B & 0\n",
     "\\end{array}\n",
     "\\right)\n",
@@ -143,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 15,
    "id": "romance-findings",
    "metadata": {},
    "outputs": [],
@@ -174,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "id": "subtle-wonder",
    "metadata": {},
    "outputs": [],
@@ -199,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 17,
    "id": "satisfactory-jerusalem",
    "metadata": {},
    "outputs": [],
@@ -210,7 +216,8 @@
     "cell_p = P0.eval_at_cell_centers(sd) * p\n",
     "\n",
     "for _, data in mdg.subdomains(return_data=True):\n",
-    "    data[pp.STATE] = {\"cell_q\": cell_q, \"cell_p\": cell_p}\n",
+    "    pp.set_solution_values(\"cell_q\", cell_q, data, 0)\n",
+    "    pp.set_solution_values(\"cell_p\", cell_p, data, 0)\n",
     "\n",
     "save = pp.Exporter(mdg, \"sol\")\n",
     "save.write_vtu([\"cell_q\", \"cell_p\"])"

--- a/tutorials/darcy.ipynb
+++ b/tutorials/darcy.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 1,
    "id": "dietary-perth",
    "metadata": {},
    "outputs": [],
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 2,
    "id": "spectacular-saturn",
    "metadata": {},
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "spare-person",
    "metadata": {},
    "outputs": [],
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "romance-findings",
    "metadata": {},
    "outputs": [],
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "subtle-wonder",
    "metadata": {},
    "outputs": [],
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "satisfactory-jerusalem",
    "metadata": {},
    "outputs": [],

--- a/tutorials/stokes.ipynb
+++ b/tutorials/stokes.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 41,
    "id": "stunning-pollution",
    "metadata": {},
    "outputs": [],
@@ -77,13 +77,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 42,
    "id": "average-cause",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# make the mixed-dimensional grid by using pp functionalities\n",
-    "domain = {\"xmin\": 0, \"xmax\": 1, \"ymin\": 0, \"ymax\": 1}\n",
+    "domain = pp.Domain({\"xmin\": 0, \"xmax\": 1, \"ymin\": 0, \"ymax\": 1})\n",
     "network = pp.create_fracture_network(domain=domain)\n",
     "\n",
     "mesh_size = 1/20\n",
@@ -105,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 43,
    "id": "painted-contractor",
    "metadata": {},
    "outputs": [],
@@ -182,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 44,
    "id": "authorized-screw",
    "metadata": {},
    "outputs": [],
@@ -217,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 45,
    "id": "injured-estimate",
    "metadata": {},
    "outputs": [],
@@ -243,26 +251,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 46,
    "id": "joined-cylinder",
    "metadata": {},
    "outputs": [],
    "source": [
     "# post process vorticity\n",
-    "proj_r = pg.eval_at_cell_centers(mdg, pg.Lagrange(keyword))\n",
-    "cell_r = proj_r * r\n",
+    "proj_r = pg.eval_at_cell_centers(mdg, pg.Lagrange1(keyword))\n",
+    "cell_r = proj_r @ r\n",
     "\n",
     "# post process velocity\n",
-    "proj_q = pg.proj_faces_to_cells(mdg)\n",
-    "cell_q = (proj_q * q).reshape((3, -1), order=\"F\")\n",
+    "proj_q = pg.eval_at_cell_centers(mdg, pg.RT0(keyword))\n",
+    "cell_q = (proj_q @ q).reshape((3, -1), order=\"F\")\n",
+    "\n",
+    "# post process pressure\n",
+    "proj_p = pg.eval_at_cell_centers(mdg, pg.PwConstants(keyword))\n",
+    "cell_p = proj_p @ p\n",
+    "\n",
     "\n",
     "# save the solutions to be exported in the data dictionary of the mdg\n",
     "for _, data in mdg.subdomains(return_data=True):\n",
-    "    data[pp.STATE] = {\"cell_r\": cell_r, \"cell_q\": cell_q, \"p\": p}\n",
+    "    pp.set_solution_values(\"cell_r\", cell_r, data, 0)\n",
+    "    pp.set_solution_values(\"cell_q\", cell_q, data, 0)\n",
+    "    pp.set_solution_values(\"cell_p\", cell_p, data, 0)\n",
     "\n",
     "# export the solutions\n",
     "save = pp.Exporter(mdg, \"sol\")\n",
-    "save.write_vtu([\"cell_r\", \"cell_q\", \"p\"])"
+    "save.write_vtu([\"cell_r\", \"cell_q\", \"cell_p\"])"
    ]
   },
   {

--- a/tutorials/stokes.ipynb
+++ b/tutorials/stokes.ipynb
@@ -84,7 +84,7 @@
    "source": [
     "# make the mixed-dimensional grid by using pp functionalities\n",
     "domain = {\"xmin\": 0, \"xmax\": 1, \"ymin\": 0, \"ymax\": 1}\n",
-    "network = pp.FractureNetwork2d(domain=domain)\n",
+    "network = pp.create_fracture_network(domain=domain)\n",
     "\n",
     "mesh_size = 1/20\n",
     "mesh_kwargs = {\"mesh_size_frac\": mesh_size, \"mesh_size_min\": mesh_size}\n",
@@ -291,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/tutorials/stokes.ipynb
+++ b/tutorials/stokes.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 1,
    "id": "stunning-pollution",
    "metadata": {},
    "outputs": [],
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 2,
    "id": "average-cause",
    "metadata": {},
    "outputs": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 3,
    "id": "painted-contractor",
    "metadata": {},
    "outputs": [],
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 4,
    "id": "authorized-screw",
    "metadata": {},
    "outputs": [],
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 5,
    "id": "injured-estimate",
    "metadata": {},
    "outputs": [],
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 6,
    "id": "joined-cylinder",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
`pp.FractureNetwork2d` and `pp.FractureNetwork3d` have been replaced by `pp.create_fracture_network`.
Exporting solutions in PorePy is now done using `pp.set_solution_values()` instead of directly setting values in `data[pp.STATE]`.