### PR TITLE
Optimize bdm1

### DIFF
--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -421,6 +421,8 @@ class BDM1(pg.Discretization):
             opposites (np.ndarray): The local degrees of freedom.
             cell_nodes_loc (np.ndarray): The local nodes of the cell.
             faces_loc (np.ndarray): The local faces.
+            return_node_ind (bool): Whether to return the local indexing of the nodes,
+                                    used in assemble_lumped_matrix
 
         Returns:
             np.ndarray: The local mass matrix.

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -369,7 +369,7 @@ class BDM1(pg.Discretization):
         data_IJ = np.empty(size)
         idx = 0
 
-        M = self.local_inner_product(sd.dim)
+        M = self.local_inner_product(sd.dim).toarray()
 
         try:
             inv_K = data[pp.PARAMETERS][self.keyword]["second_order_tensor"]
@@ -385,9 +385,9 @@ class BDM1(pg.Discretization):
             faces_loc = sd.cell_faces.indices[loc]
             opposites_loc = opposite_nodes.data[loc]
 
-            Psi = self.eval_basis_at_node(sd, opposites_loc, faces_loc)
+            Psi = self.eval_basis_at_node(sd, opposites_loc, faces_loc).toarray()
 
-            weight = sps.block_diag([inv_K.values[:, :, c]] * (sd.dim + 1))
+            weight = np.kron(np.eye(sd.dim + 1),inv_K.values[:, :, c])
 
             # Compute the inner products
             A = Psi @ M @ weight @ Psi.T * sd.cell_volumes[c]
@@ -400,7 +400,7 @@ class BDM1(pg.Discretization):
             loc_idx = slice(idx, idx + cols.size)
             rows_I[loc_idx] = cols.T.ravel()
             cols_J[loc_idx] = cols.ravel()
-            data_IJ[loc_idx] = A.todense().ravel()
+            data_IJ[loc_idx] = A.ravel()
             idx += cols.size
 
         # Construct the global matrices

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -426,9 +426,10 @@ class BDM1(pg.Discretization):
             np.ndarray: The local mass matrix.
         """
         fn = sd.face_nodes
-        nodes = np.vstack(
-            [fn.indices[fn.indptr[face] : fn.indptr[face + 1]] for face in faces_loc]
-        ).ravel(order="F")
+        nodes = np.empty((sd.dim + 1, sd.dim), int)
+        for ind, face in enumerate(faces_loc):
+            nodes[ind] = fn.indices[fn.indptr[face] : fn.indptr[face + 1]]
+        nodes = nodes.ravel(order="F")
 
         node_ind = np.repeat(np.arange(sd.dim + 1), sd.dim)
 

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -876,20 +876,17 @@ class VecBDM1(pg.VecDiscretization):
         data_IJ = np.empty(size)
         idx = 0
 
-        cell_nodes = sd.cell_nodes()
+        opposite_nodes = sd.compute_opposite_nodes()
+
         for c in np.arange(sd.num_cells):
             # For the current cell retrieve its faces and
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
-            dof_loc = np.reshape(
-                sd.face_nodes[:, faces_loc].indices, (sd.dim, -1), order="F"
-            )
+            opposites_loc = opposite_nodes[faces_loc, c].data
 
-            cell_nodes_loc = cell_nodes[:, c].toarray()
-            Psi = self.scalar_discr.eval_basis_at_node(
-                sd, dof_loc, cell_nodes_loc, faces_loc
-            )
+            Psi = self.scalar_discr.eval_basis_at_node(sd, opposites_loc, faces_loc)
+
             # Get all the components of the basis at node
             Psi_i, Psi_j, Psi_v = sps.find(Psi)
 
@@ -959,20 +956,16 @@ class VecBDM1(pg.VecDiscretization):
         else:
             raise ValueError("The grid should be either two or three-dimensional")
 
-        cell_nodes = sd.cell_nodes()
+        opposite_nodes = sd.compute_opposite_nodes()
+
         for c in np.arange(sd.num_cells):
             # For the current cell retrieve its faces and
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
-            dof_loc = np.reshape(
-                sd.face_nodes[:, faces_loc].indices, (sd.dim, -1), order="F"
-            )
 
-            cell_nodes_loc = cell_nodes[:, c].toarray()
-            Psi = self.scalar_discr.eval_basis_at_node(
-                sd, dof_loc, cell_nodes_loc, faces_loc
-            )
+            opposites_loc = opposite_nodes[faces_loc, c].data
+            Psi = self.scalar_discr.eval_basis_at_node(sd, opposites_loc, faces_loc)
 
             # Get all the components of the basis at node
             Psi_i, Psi_j, Psi_v = sps.find(Psi)

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -383,8 +383,8 @@ class BDM1(pg.Discretization):
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
+            opposites_loc = opposite_nodes.data[loc]
 
-            opposites_loc = opposite_nodes[faces_loc, c].data
             Psi = self.eval_basis_at_node(sd, opposites_loc, faces_loc)
 
             weight = sps.block_diag([inv_K.values[:, :, c]] * (sd.dim + 1))
@@ -531,8 +531,7 @@ class BDM1(pg.Discretization):
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
-
-            opposites_loc = opposite_nodes[faces_loc, c].data
+            opposites_loc = opposite_nodes.data[loc]
 
             Psi = self.eval_basis_at_node(sd, opposites_loc, faces_loc).todense()
             basis_at_center = np.sum(np.split(Psi, sd.dim + 1, axis=1), axis=0) / (
@@ -882,7 +881,7 @@ class VecBDM1(pg.VecDiscretization):
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
-            opposites_loc = opposite_nodes[faces_loc, c].data
+            opposites_loc = opposite_nodes.data[loc]
 
             Psi = self.scalar_discr.eval_basis_at_node(sd, opposites_loc, faces_loc)
 
@@ -963,8 +962,8 @@ class VecBDM1(pg.VecDiscretization):
             # determine the location of the dof
             loc = slice(sd.cell_faces.indptr[c], sd.cell_faces.indptr[c + 1])
             faces_loc = sd.cell_faces.indices[loc]
+            opposites_loc = opposite_nodes.data[loc]
 
-            opposites_loc = opposite_nodes[faces_loc, c].data
             Psi = self.scalar_discr.eval_basis_at_node(sd, opposites_loc, faces_loc)
 
             # Get all the components of the basis at node

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -424,13 +424,9 @@ class BDM1(pg.Discretization):
         Returns:
             np.ndarray: The local mass matrix.
         """
-        if sd.face_nodes.has_sorted_indices:
-            nodes = sps.find(sd.face_nodes[:, faces_loc])[0]
-            node_ind = np.repeat(np.arange(sd.dim + 1), sd.dim)
-        else:
-            nodes_loc = sd.face_nodes[:, faces_loc].indices
-            nodes = nodes_loc.reshape((sd.dim, -1), order="F").ravel()
-            node_ind = np.unique(nodes, return_inverse=True)[1]
+        nodes_loc = sd.face_nodes[:, faces_loc].indices
+        nodes = nodes_loc.reshape((sd.dim, -1), order="F").ravel()
+        node_ind = np.unique(nodes, return_inverse=True)[1]
 
         face_ind = np.tile(np.arange(sd.dim + 1), sd.dim)
 

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -429,7 +429,10 @@ class BDM1(pg.Discretization):
             [fn.indices[fn.indptr[face] : fn.indptr[face + 1]] for face in faces_loc]
         ).ravel(order="F")
 
-        node_ind = np.unique(nodes, return_inverse=True)[1]
+        node_ind = np.repeat(np.arange(sd.dim + 1), sd.dim)
+
+        if not np.all(nodes[:: sd.dim][node_ind] == nodes):
+            node_ind = np.unique(nodes, return_inverse=True)[1]
 
         face_ind = np.tile(np.arange(sd.dim + 1), sd.dim)
 

--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -296,6 +296,10 @@ class Grid(pp.Grid):
         Computes a matrix containing the index of the opposite node
         for every (face, cell) pair. Sets it as an attribute for later use.
 
+        Args:
+            recompute (bool, optional): Whether to recompute the opposite nodes.
+                                        Defaults to False.
+
         Returns:
             sps.csc_matrix: the index k of the opposite node is in the entry (face, cell)
         """

--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -290,3 +290,21 @@ class Grid(pp.Grid):
             )
         else:
             return self.face_nodes @ div_by_nodes_per_face @ sub_simplices
+
+    def compute_opposite_nodes(self, recompute=False) -> sps.csc_matrix:
+        """
+        Computes a matrix containing the index of the opposite node for every (face, cell) pair.
+        Sets it as an attribute for later use.
+
+        Returns:
+            sps.csc_matrix: the index k of the opposite node is in the entry (face, cell)
+        """
+        if recompute or not hasattr(self, "opposite_nodes"):
+            cell_nodes = self.cell_nodes()
+            faces, cells, _ = sps.find(self.cell_faces)
+
+            opposites = cell_nodes[:, cells] - self.face_nodes[:, faces].astype(bool)
+
+            self.opposite_nodes = sps.csc_matrix((opposites.indices, (faces, cells)))
+
+        return self.opposite_nodes

--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -301,6 +301,12 @@ class Grid(pp.Grid):
         """
         if recompute or not hasattr(self, "opposite_nodes"):
             cell_nodes = self.cell_nodes()
+
+            if not np.all(cell_nodes.sum(axis=0) == self.dim + 1):
+                raise NotImplementedError(
+                    "Grid is not simplicial; cannot compute opposite node."
+                )
+
             faces, cells, _ = sps.find(self.cell_faces)
 
             opposites = cell_nodes[:, cells] - self.face_nodes[:, faces].astype(bool)

--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -293,8 +293,8 @@ class Grid(pp.Grid):
 
     def compute_opposite_nodes(self, recompute=False) -> sps.csc_matrix:
         """
-        Computes a matrix containing the index of the opposite node for every (face, cell) pair.
-        Sets it as an attribute for later use.
+        Computes a matrix containing the index of the opposite node
+        for every (face, cell) pair. Sets it as an attribute for later use.
 
         Returns:
             sps.csc_matrix: the index k of the opposite node is in the entry (face, cell)

--- a/tests/integration/test_elasticity.py
+++ b/tests/integration/test_elasticity.py
@@ -247,7 +247,7 @@ class ElasticityTestMixed(unittest.TestCase):
         vec_p0 = pg.VecPwConstants(key)
 
         data = {pp.PARAMETERS: {key: {"mu": 0.5, "lambda": 0.5}}}
-        Ms = vec_bdm1.assemble_lumped_matrix(sd, data)
+        Ms = vec_bdm1.assemble_mass_matrix(sd, data)
         Mu = vec_p0.assemble_mass_matrix(sd)
         Mr = Mu
 

--- a/tests/integration/test_elasticity.py
+++ b/tests/integration/test_elasticity.py
@@ -247,7 +247,13 @@ class ElasticityTestMixed(unittest.TestCase):
         vec_p0 = pg.VecPwConstants(key)
 
         data = {pp.PARAMETERS: {key: {"mu": 0.5, "lambda": 0.5}}}
+        import time
+
+        t = time.time()
         Ms = vec_bdm1.assemble_mass_matrix(sd, data)
+        print("Important: {}".format(time.time() - t))
+
+        return
         Mu = vec_p0.assemble_mass_matrix(sd)
         Mr = Mu
 
@@ -278,7 +284,7 @@ class ElasticityTestMixed(unittest.TestCase):
         return cell_sigma, cell_u, cell_r, sd
 
     def test_elasticity_rbm_3d(self):
-        N = 3
+        N = 7
         u_boundary = lambda x: np.array([-0.5 - x[1], -0.5 + x[0] - x[2], -0.5 + x[1]])
         cell_sigma, cell_u, cell_r, sd = self.run_elasticity_3d(u_boundary, N)
 
@@ -323,4 +329,5 @@ class ElasticityTestMixed(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
+    ElasticityTestMixed().test_elasticity_rbm_3d()

--- a/tests/integration/test_elasticity.py
+++ b/tests/integration/test_elasticity.py
@@ -247,13 +247,7 @@ class ElasticityTestMixed(unittest.TestCase):
         vec_p0 = pg.VecPwConstants(key)
 
         data = {pp.PARAMETERS: {key: {"mu": 0.5, "lambda": 0.5}}}
-        import time
-
-        t = time.time()
-        Ms = vec_bdm1.assemble_mass_matrix(sd, data)
-        print("Important: {}".format(time.time() - t))
-
-        return
+        Ms = vec_bdm1.assemble_lumped_matrix(sd, data)
         Mu = vec_p0.assemble_mass_matrix(sd)
         Mr = Mu
 
@@ -284,7 +278,7 @@ class ElasticityTestMixed(unittest.TestCase):
         return cell_sigma, cell_u, cell_r, sd
 
     def test_elasticity_rbm_3d(self):
-        N = 7
+        N = 3
         u_boundary = lambda x: np.array([-0.5 - x[1], -0.5 + x[0] - x[2], -0.5 + x[1]])
         cell_sigma, cell_u, cell_r, sd = self.run_elasticity_3d(u_boundary, N)
 
@@ -329,5 +323,4 @@ class ElasticityTestMixed(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # unittest.main()
-    ElasticityTestMixed().test_elasticity_rbm_3d()
+    unittest.main()

--- a/tests/unit/test_opposite_node.py
+++ b/tests/unit/test_opposite_node.py
@@ -1,0 +1,51 @@
+import unittest
+
+import numpy as np
+import porepy as pp
+import scipy.sparse as sps
+
+import pygeon as pg
+
+"""
+Module contains a unit tests to validate the opposite_node computations on simplicial grids.
+"""
+
+
+class OppositeNode_Test(unittest.TestCase):
+    def test_grid_2d_tris(self):
+        N = 1
+        sd = pp.StructuredTriangleGrid([N] * 2)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        opposite_node = sd.compute_opposite_nodes()
+        known_data = np.array([3, 1, 0, 3, 2, 0])
+
+        self.assertTrue(opposite_node.nnz == sd.num_cells * (sd.dim + 1))
+        self.assertTrue(np.all(known_data == opposite_node.data))
+
+    def test_grid_3d_tets(self):
+        N = 1
+        sd = pp.StructuredTetrahedralGrid([N] * 3)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        opposite_node = sd.compute_opposite_nodes()
+        known_data = np.array(
+            [4, 2, 1, 0, 6, 4, 2, 1, 6, 5, 4, 1, 6, 3, 2, 1, 6, 5, 3, 1, 7, 6, 5, 3]
+        )
+
+        self.assertTrue(opposite_node.nnz == sd.num_cells * (sd.dim + 1))
+        self.assertTrue(np.all(known_data == opposite_node.data))
+
+    def test_non_simplicial_grid(self):
+        N = 1
+        sd = pp.CartGrid([N] * 2)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        self.assertRaises(NotImplementedError, sd.compute_opposite_nodes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_spanningtree.py
+++ b/tests/unit/test_spanningtree.py
@@ -267,7 +267,7 @@ class SpanningTreeCosseratTest(unittest.TestCase):
         self.check(sd)
 
     def test_assemble_SI(self):
-        N, dim = 3, 3
+        N, dim = 2, 3
         sd = pp.StructuredTetrahedralGrid([N] * dim, [1] * dim)
         mdg = pg.as_mdg(sd)
         pg.convert_from_pp(mdg)


### PR DESCRIPTION
The BDM1 assemblies were based on slow commands like `sps.find`.
This PR speeds up these assemblies by using dense local matrices instead of sparse ones