### PR TITLE
Edge lengths

### DIFF
--- a/tests/unit/test_grid_edge_lengths.py
+++ b/tests/unit/test_grid_edge_lengths.py
@@ -19,13 +19,14 @@ class EdgeLengthTest(unittest.TestCase):
         self.assertTrue(len(sd.edge_lengths) == 0)
         self.assertTrue(np.isnan(sd.mesh_size))
 
-    def test_grid_1d_lines(self):
-        sd = pp.CartGrid([2], 1)
-        pg.convert_from_pp(sd)
-        sd.compute_geometry()
+    def test_cartgrids(self):
+        for dim in np.arange(1, 4):
+            sd = pp.CartGrid([2] * dim, [1] * dim)
+            pg.convert_from_pp(sd)
+            sd.compute_geometry()
 
-        self.assertTrue(np.allclose(sd.edge_lengths, 0.5))
-        self.assertTrue(np.allclose(sd.mesh_size, 0.5))
+            self.assertTrue(np.allclose(sd.edge_lengths, 0.5))
+            self.assertTrue(np.allclose(sd.mesh_size, 0.5))
 
     def test_grid_2d_tris(self):
         sd = pp.StructuredTriangleGrid([1] * 2)
@@ -52,13 +53,6 @@ class EdgeLengthTest(unittest.TestCase):
 
         known_meshsize = (12 + 6 * np.sqrt(2) + np.sqrt(3)) / 19
         self.assertTrue(np.allclose(sd.mesh_size, known_meshsize))
-
-    def test_non_simplicial_grid(self):
-        sd = pp.CartGrid([1] * 2)
-        pg.convert_from_pp(sd)
-        sd.compute_geometry()
-
-        self.assertRaises(TypeError, sd.compute_opposite_nodes)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_grid_edge_lengths.py
+++ b/tests/unit/test_grid_edge_lengths.py
@@ -1,0 +1,66 @@
+import unittest
+
+import numpy as np
+import porepy as pp
+
+import pygeon as pg
+
+"""
+Module contains a unit tests to validate the edge length computations for grids
+"""
+
+
+class EdgeLengthTest(unittest.TestCase):
+    def test_grid_0d(self):
+        sd = pp.PointGrid([0, 0, 0])
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        self.assertTrue(len(sd.edge_lengths) == 0)
+        self.assertTrue(np.isnan(sd.mesh_size))
+
+    def test_grid_1d_lines(self):
+        sd = pp.CartGrid([2], 1)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        self.assertTrue(np.allclose(sd.edge_lengths, 0.5))
+        self.assertTrue(np.allclose(sd.mesh_size, 0.5))
+
+    def test_grid_2d_tris(self):
+        sd = pp.StructuredTriangleGrid([1] * 2)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        unique_lengths = np.unique(sd.edge_lengths)
+        known_lengths = np.sqrt(np.arange(1, 3))
+
+        self.assertTrue(np.allclose(unique_lengths, known_lengths))
+
+        known_meshsize = (4 + np.sqrt(2)) / 5
+        self.assertTrue(np.allclose(sd.mesh_size, known_meshsize))
+
+    def test_grid_3d_tets(self):
+        sd = pp.StructuredTetrahedralGrid([1] * 3)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        unique_lengths = np.unique(sd.edge_lengths)
+        known_lengths = np.sqrt(np.arange(1, 4))
+
+        self.assertTrue(np.allclose(unique_lengths, known_lengths))
+
+        known_meshsize = (12 + 6 * np.sqrt(2) + np.sqrt(3)) / 19
+        self.assertTrue(np.allclose(sd.mesh_size, known_meshsize))
+
+    def test_non_simplicial_grid(self):
+        sd = pp.CartGrid([1] * 2)
+        pg.convert_from_pp(sd)
+        sd.compute_geometry()
+
+        self.assertRaises(TypeError, sd.compute_opposite_nodes)
+
+
+if __name__ == "__main__":
+
+    unittest.main()

--- a/tests/unit/test_grid_edge_tangents.py
+++ b/tests/unit/test_grid_edge_tangents.py
@@ -10,14 +10,15 @@ Module contains a unit tests to validate the edge length computations for grids
 """
 
 
-class EdgeLengthTest(unittest.TestCase):
+class EdgeTangentTest(unittest.TestCase):
     def test_grid_0d(self):
         sd = pp.PointGrid([0, 0, 0])
         pg.convert_from_pp(sd)
         sd.compute_geometry()
 
+        self.assertTrue(len(sd.edge_tangents) == 0)
         self.assertTrue(len(sd.edge_lengths) == 0)
-        self.assertTrue(np.isnan(sd.mesh_size))
+        self.assertTrue(sd.mesh_size == 0)
 
     def test_cartgrids(self):
         for dim in np.arange(1, 4):
@@ -37,6 +38,7 @@ class EdgeLengthTest(unittest.TestCase):
         known_lengths = np.sqrt(np.arange(1, 3))
 
         self.assertTrue(np.allclose(unique_lengths, known_lengths))
+        self.assertTrue(np.allclose(sd.edge_lengths, sd.face_areas))
 
         known_meshsize = (4 + np.sqrt(2)) / 5
         self.assertTrue(np.allclose(sd.mesh_size, known_meshsize))
@@ -56,5 +58,4 @@ class EdgeLengthTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-
     unittest.main()

--- a/tests/unit/test_grid_edge_tangents.py
+++ b/tests/unit/test_grid_edge_tangents.py
@@ -39,6 +39,9 @@ class EdgeTangentTest(unittest.TestCase):
 
         self.assertTrue(np.allclose(unique_lengths, known_lengths))
         self.assertTrue(np.allclose(sd.edge_lengths, sd.face_areas))
+        self.assertTrue(
+            np.allclose(np.sum(sd.edge_tangents * sd.face_normals, axis=0), 0)
+        )
 
         known_meshsize = (4 + np.sqrt(2)) / 5
         self.assertTrue(np.allclose(sd.mesh_size, known_meshsize))


### PR DESCRIPTION
Included the computation of edge lengths and mesh size in ``Grid.compute_geometry()``. These are fast computations that require negligible overhead.
