### PR TITLE
remove explicit cell_nodes parameter in cell_diameters

### DIFF
--- a/src/pygeon/discretizations/vem/h1.py
+++ b/src/pygeon/discretizations/vem/h1.py
@@ -28,7 +28,7 @@ class VLagrange1(pg.Lagrange1):
         """
         # Precomputations
         cell_nodes = sd.cell_nodes()
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         # Data allocation
         size = np.sum(np.square(cell_nodes.sum(0)))
@@ -226,7 +226,7 @@ class VLagrange1(pg.Lagrange1):
         """
         # Precomputations
         cell_nodes = sd.cell_nodes()
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         # Data allocation
         size = np.sum(np.square(cell_nodes.sum(0)))

--- a/src/pygeon/discretizations/vem/hdiv.py
+++ b/src/pygeon/discretizations/vem/hdiv.py
@@ -116,7 +116,7 @@ class VBDM1(pg.BDM1):
         disc_VL1 = pg.VLagrange1(pg.UNITARY_DATA)
 
         tangents = sd.nodes @ sd.face_ridges
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         for cell, diam in enumerate(cell_diams):
             cell_col = np.array([cell])

--- a/src/pygeon/discretizations/vem/vec_h1.py
+++ b/src/pygeon/discretizations/vem/vec_h1.py
@@ -64,7 +64,7 @@ class VecVLagrange1(pg.VecDiscretization):
             sps.csc_array: The div matrix obtained from the discretization.
         """
         cell_nodes = sd.cell_nodes()
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         # Allocate the data to store matrix entries, that's the most efficient
         # way to create a sparse matrix.
@@ -166,7 +166,7 @@ class VecVLagrange1(pg.VecDiscretization):
 
         """
         cell_nodes = sd.cell_nodes()
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         # Allocate the data to store matrix entries, that's the most efficient
         # way to create a sparse matrix.
@@ -282,7 +282,7 @@ class VecVLagrange1(pg.VecDiscretization):
         """
         # Precomputations
         cell_nodes = sd.cell_nodes()
-        cell_diams = sd.cell_diameters(cell_nodes)
+        cell_diams = sd.cell_diameters()
 
         # Data allocation
         size = np.sum(np.square(cell_nodes.sum(0)))


### PR DESCRIPTION
remove explicit cell_nodes parameter in cell_diameters call due to the fact that unhashable type: 'csc_array' for cell_nodes. internally the cell_nodes computation is called and this solves the problem