### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,6 +1,8 @@
 # Adapted from PorePy
 # Run unit, integration, and functional tests.
 name: Pytest
+permissions:
+  contents: read
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches


### PR DESCRIPTION
Potential fix for [https://github.com/compgeo-mox/pygeon/security/code-scanning/7](https://github.com/compgeo-mox/pygeon/security/code-scanning/7)

The best fix is to add a `permissions` block to restrict the permissions granted to the GITHUB_TOKEN used by this workflow/job. We can add this block either at the workflow root (before `jobs:`), or within the `build:` job definition, but adding at the root applies by default to all jobs and is preferred unless some jobs need wider permissions.

Read-only access to `contents` is sufficient: `permissions: contents: read`. To implement the fix, add the following lines (properly indented) at the top level of `.github/workflows/run-pytest.yml`—between the last trigger/schedule block and before `jobs:`, or right after the workflow `name:` if that's the clearest/most standard location.

No other imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
