### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-static-checks.yml
+++ b/.github/workflows/run-static-checks.yml
@@ -2,6 +2,8 @@
 # Run static tests for code quality: Isort, ruff (formatting and linting), mypy.
 
 name: Static tests
+permissions:
+  contents: read
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events for the main and develop branches


### PR DESCRIPTION
Potential fix for [https://github.com/compgeo-mox/pygeon/security/code-scanning/2](https://github.com/compgeo-mox/pygeon/security/code-scanning/2)

To fix the issue, explicitly set a `permissions` block at the workflow or job level with the minimum required privileges. In most cases for static code analysis workflows, only read access to repository contents is required, so set `permissions: contents: read` at the root (top) of the workflow file, just after the `name:` declaration and before `on:`. If any jobs or steps require more privileges, you can override or extend the permissions at the job level, but for this workflow and the provided content, `contents: read` at the workflow level is sufficient. No additional code changes, imports, or method definitions are needed beyond this edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
