### PR TITLE
Tensor-valued parameters in data

### DIFF
--- a/src/pygeon/discretizations/fem/h1.py
+++ b/src/pygeon/discretizations/fem/h1.py
@@ -103,7 +103,7 @@ class Lagrange1(pg.Discretization):
         Returns:
             sps.csc_array: The assembled stiffness matrix.
         """
-        K = pg.get_cell_data(sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR)
+        K = pg.get_cell_data(sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX)
 
         # Map the domain to a reference geometry (i.e. equivalent to compute
         # surface coordinates in 1d and 2d)
@@ -611,7 +611,7 @@ class Lagrange2(pg.Discretization):
             sps.csc_array: The stiffness matrix.
         """
         sot = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         size = np.square((sd.dim + 1) + self.num_edges_per_cell(sd.dim)) * sd.num_cells

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -81,7 +81,7 @@ class RT0(pg.Discretization):
             return sps.csc_array((sd.num_faces, sd.num_faces))
 
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         # Map the domain to a reference geometry (i.e. equivalent to compute
@@ -255,7 +255,7 @@ class RT0(pg.Discretization):
             sps.csc_array: The lumped mass matrix.
         """
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         h_perp = np.zeros(sd.num_faces)
@@ -431,7 +431,7 @@ class BDM1(pg.Discretization):
         M = self.local_inner_product(sd.dim)
 
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         opposite_nodes = sd.compute_opposite_nodes()
@@ -741,7 +741,7 @@ class BDM1(pg.Discretization):
         idx = 0
 
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         opposite_nodes = sd.compute_opposite_nodes()
@@ -895,7 +895,7 @@ class RT1(pg.Discretization):
             return sps.csc_array((0, 0))
 
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         # Allocate the data to store matrix A entries
@@ -1301,7 +1301,7 @@ class RT1(pg.Discretization):
         bdm1_lumped = bdm1.assemble_lumped_matrix(sd, data) / (sd.dim + 2)
 
         inv_K = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
 
         # Allocate the data to store matrix P entries

--- a/src/pygeon/discretizations/fem/vec_l2.py
+++ b/src/pygeon/discretizations/fem/vec_l2.py
@@ -39,7 +39,7 @@ class VecPwPolynomials(pg.VecDiscretization):
         # Retrieve the second-order tensor from the data and assemble the weighting
         # matrix.
         sot = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
         W = self.assemble_weighting_matrix(sd, sot)
 

--- a/src/pygeon/discretizations/vem/hdiv.py
+++ b/src/pygeon/discretizations/vem/hdiv.py
@@ -53,7 +53,7 @@ class VRT0(pg.RT0):
             sps.csc_array: The mass matrix.
         """
         perm = pg.get_cell_data(
-            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+            sd, data, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
         )
         data = data if data is not None else {}
         data = pp.initialize_data(data, self.keyword, {pg.SECOND_ORDER_TENSOR: perm})
@@ -75,7 +75,7 @@ class VRT0(pg.RT0):
         Returns:
             sps.csc_array: The evaluation matrix.
         """
-        perm = pg.get_cell_data(sd, {}, self.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR)
+        perm = pg.get_cell_data(sd, {}, self.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX)
         data = pp.initialize_data({}, self.keyword, {pg.SECOND_ORDER_TENSOR: perm})
 
         discr = self.ref_discr(self.keyword)

--- a/src/pygeon/params/data.py
+++ b/src/pygeon/params/data.py
@@ -63,7 +63,7 @@ def get_cell_data(
             data[pp.PARAMETERS].
         param (str): The parameter name to retrieve from the data dictionary.
         tensor_order (int): The tensor order of the data. Default is pg.SCALAR.
-            If pg.VECTOR, the result is wrapped in a pp.SecondOrderTensor.
+            If pg.MATRIX, the result is wrapped in a pp.SecondOrderTensor.
 
     Returns:
         np.ndarray | pp.SecondOrderTensor: The parameter values for all cells.
@@ -94,7 +94,7 @@ def get_cell_data(
         value = np.full(sd.num_cells, value)
 
         # Wrap vector tensor orders in a SecondOrderTensor
-        if tensor_order == pg.VECTOR:
+        if tensor_order == pg.MATRIX:
             value = pp.SecondOrderTensor(value)
 
     return value

--- a/tests/discretizations/fem/hdiv/test_rt0.py
+++ b/tests/discretizations/fem/hdiv/test_rt0.py
@@ -63,7 +63,7 @@ def test_mass_matrix_vs_pp(discr, unit_sd):
     discr_pp = pp.RT0(discr.keyword)
 
     perm = pg.get_cell_data(
-        unit_sd, {}, discr.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+        unit_sd, {}, discr.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
     )
     data = pp.initialize_data({}, discr.keyword, {pg.SECOND_ORDER_TENSOR: perm})
 
@@ -82,7 +82,7 @@ def test_eval_at_cc_vs_pp(discr, unit_sd):
     discr_pp = pp.RT0(discr.keyword)
 
     perm = pg.get_cell_data(
-        unit_sd, {}, discr.keyword, pg.SECOND_ORDER_TENSOR, pg.VECTOR
+        unit_sd, {}, discr.keyword, pg.SECOND_ORDER_TENSOR, pg.MATRIX
     )
     data = pp.initialize_data({}, discr.keyword, {pg.SECOND_ORDER_TENSOR: perm})
 


### PR DESCRIPTION
The function `get_cell_data` has the option to specify a tensor-order for the output. It is confusing to specify `pg.VECTOR` if you want the function to return a matrix-valued field.

This PR changes the behavior of `get_cell_data` so that a 2-tensor is returned if `tensor_order == pg.MATRIX`. In advection problems, we may want to specify a vector-valued field, so the `tensor_order == pg.VECTOR` should be reserved for that.
