### PR TITLE
Ridge computation

### DIFF
--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -57,11 +57,11 @@ class Grid(pp.Grid):
             None
         """
         super().compute_geometry()
+        self.compute_rotation_matrix()
         self.compute_ridges()
 
         self.compute_edge_properties()
         self.compute_mesh_size()
-        self.compute_rotation_matrix()
 
     def compute_ridges(self) -> None:
         """
@@ -131,8 +131,8 @@ class Grid(pp.Grid):
 
         # We compute the face tangential by mapping the face normal to a reference grid
         # in the xy-plane, rotating locally, and mapping back.
-        R = pp.map_geometry.project_plane_matrix(self.nodes)
-        loc_rot = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        R = self.rotation_matrix
+        loc_rot = np.array([[0.0, -1.0], [1.0, 0.0]])
         rot = R.T @ loc_rot @ R
         rotated_normal = rot @ self.face_normals
 

--- a/src/pygeon/grids/mortar_grid.py
+++ b/src/pygeon/grids/mortar_grid.py
@@ -62,16 +62,11 @@ class MortarGrid(pp.MortarGrid):
 
         # Find information about the two-dimensional grid
         if self.dim == 1:
-            R = pp.map_geometry.project_plane_matrix(sd_up.nodes)
-            rot = np.dot(
-                R.T,
-                np.dot(
-                    np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]), R
-                ),
-            )
+            R = sd_up.rotation_matrix
+            rot = R.T @ np.array([[0.0, -1.0], [1.0, 0.0]]) @ R
         else:  # self.dim == 2
-            R = pp.map_geometry.project_plane_matrix(sd_down.nodes)
-            normal_to_sd_down = np.dot(R.T, [0, 0, 1])
+            R = sd_down.rotation_matrix
+            normal_to_sd_down = np.cross(R[0], R[1])
 
         for face_up, cell_down in zip(*sps.find(self.cell_faces)[:-1]):
             # Faces of cell in lower-dim grid

--- a/src/pygeon/grids/mortar_grid.py
+++ b/src/pygeon/grids/mortar_grid.py
@@ -68,6 +68,10 @@ class MortarGrid(pp.MortarGrid):
             R = sd_down.rotation_matrix
             normal_to_sd_down = np.cross(R[0], R[1])
 
+        # We look at (face_up, cell_down) pairs and match up the adjacent ridges and
+        # peaks. We cannot rely on fast pairing based on coordinates because entities
+        # get duplicated if a fracture crosses through. This way, we ensure that the
+        # connectivity is preserved.
         for face_up, cell_down in zip(*sps.find(self.cell_faces)[:-1]):
             # Faces of cell in lower-dim grid
             cf_down = sd_down.cell_faces

--- a/src/pygeon/grids/mortar_grid.py
+++ b/src/pygeon/grids/mortar_grid.py
@@ -68,6 +68,11 @@ class MortarGrid(pp.MortarGrid):
             R = sd_down.rotation_matrix
             normal_to_sd_down = np.cross(R[0], R[1])
 
+        # Pre-computations to remove unnecessary recomputation.
+        cf_csr = sd_up.cell_faces.tocsr()
+        if self.dim == 2:
+            cr_down = sd_down.cell_nodes()
+
         # We look at (face_up, cell_down) pairs and match up the adjacent ridges and
         # peaks. We cannot rely on fast pairing based on coordinates because entities
         # get duplicated if a fracture crosses through. This way, we ensure that the
@@ -84,11 +89,10 @@ class MortarGrid(pp.MortarGrid):
             ridges_up = fr_up.indices[fr_up.indptr[face_up] : fr_up.indptr[face_up + 1]]
 
             # Swap ridges around so they match with lower-dim faces
+            face_xyz = sd_down.face_centers[:, faces_down]
             if self.dim == 1:
-                face_xyz = sd_down.face_centers[:, faces_down]
                 ridge_xyz = sd_up.nodes[:, ridges_up]
             else:  # self.dim == 2
-                face_xyz = sd_down.nodes @ abs(sd_down.face_ridges[:, faces_down]) / 2
                 ridge_xyz = sd_up.nodes @ abs(sd_up.ridge_peaks[:, ridges_up]) / 2
 
             ridges_up = ridges_up[match_coordinates(face_xyz, ridge_xyz)]
@@ -96,7 +100,6 @@ class MortarGrid(pp.MortarGrid):
             # Ridge-peak connectivity in 3D
             if self.dim == 2:
                 # Ridges of cell in lower-dim grid
-                cr_down = sd_down.cell_nodes()
                 ridges_down = cr_down.indices[
                     cr_down.indptr[cell_down] : cr_down.indptr[cell_down + 1]
                 ]
@@ -117,7 +120,7 @@ class MortarGrid(pp.MortarGrid):
             # vector
 
             # Find the normal vector oriented outward wrt the higher-dim grid
-            is_outward = sd_up.cell_faces.tocsr()[face_up, :].data[0]
+            is_outward = cf_csr[face_up, :].data[0]
             normal_up = sd_up.face_normals[:, face_up] * is_outward
 
             # Find the normal to the lower-dim face
@@ -128,13 +131,13 @@ class MortarGrid(pp.MortarGrid):
                 # we say that orientations align if the rotated mortar
                 # normal corresponds to the normal of the
                 # lower-dimensional face
-                orientations_fr = np.dot(np.dot(rot, normal_up), normal_down)
+                orientations_fr = np.dot(rot @ normal_up, normal_down)
 
             else:  # self.dim == 2
                 # we say that orientations align if the cross product
                 # between the ridge tangent and the mortar normal corresponds
                 # to the normal of the lower-dimensional face
-                tangents = sd_up.nodes @ sd_up.ridge_peaks[:, ridges_up]
+                tangents = sd_up.edge_tangents[:, ridges_up]
                 products = np.cross(tangents, normal_up, axisa=0, axisc=0)
                 orientations_fr = [
                     np.dot(products[:, i], normal_down[:, i])
@@ -143,8 +146,8 @@ class MortarGrid(pp.MortarGrid):
 
                 # The (virtual) line connecting the low-dim ridge to
                 # the high-dim is oriented according to the normal to the fracture plane
-                orientations_rp = -np.dot(normal_up, normal_to_sd_down) * np.ones(
-                    peaks_up.shape
+                orientations_rp = np.full(
+                    peaks_up.shape, -np.dot(normal_up, normal_to_sd_down)
                 )
                 ridge_peaks[peaks_up, ridges_down] += np.sign(orientations_rp)
 

--- a/tests/grids/test_grid_ridges.py
+++ b/tests/grids/test_grid_ridges.py
@@ -97,7 +97,7 @@ def test_mdg_3d(_mdg_dict):
     assert mg.ridge_peaks.nnz == 2 * (frac_sd.num_nodes - num_tip_nodes)
 
     # TODO: Find bug in the ridge computation so that the following assertion holds
-    # assert mg.face_ridges.nnz == 2 * (frac_sd.num_faces - num_tip_nodes)
+    assert mg.face_ridges.nnz == 2 * (frac_sd.num_faces - num_tip_nodes)
 
 
 def test_mdg_3d_itsc(_mdg_dict):

--- a/tests/grids/test_grid_ridges.py
+++ b/tests/grids/test_grid_ridges.py
@@ -107,7 +107,6 @@ def test_mdg_3d(mdg):
 def test_mdg_3d_itsc(_mdg_dict):
     mdg = _mdg_dict["fracs_3D"]
 
-    for mg in mdg.interfaces():
-        if mg.dim == 1:
-            assert mg.ridge_peaks.shape == (0, 0)
-            assert mg.face_ridges.shape == (20, 2)
+    for mg in mdg.interfaces(dim=1):
+        assert mg.ridge_peaks.shape == (0, 0)
+        assert mg.face_ridges.shape == (20, 2)

--- a/tests/grids/test_grid_ridges.py
+++ b/tests/grids/test_grid_ridges.py
@@ -89,16 +89,19 @@ def test_mdg_2d(mdg_embedded_frac_2d):
 
 def test_mdg_3d(mdg):
     for mg in mdg.interfaces():
-        frac_sd = mg.sd_pair[1]
-        num_tip_nodes = frac_sd.tags["tip_nodes"].sum()
+        sd_down = mg.sd_pair[1]
 
-        # Check that the lower-dimensional faces occur twice
+        # Check that the lower-dimensional faces occur twice, except at tips.
         if mg.dim >= 1:
-            assert mg.face_ridges.nnz == 2 * (frac_sd.num_faces - num_tip_nodes)
+            sums = np.sum(np.abs(mg.face_ridges), axis=0)
+            assert np.allclose(sums[sd_down.tags["tip_faces"]], 0)
+            assert np.allclose(sums[~sd_down.tags["tip_faces"]], 2)
 
-        # Check that the lower-dimensional ridges occur twice
+        # Check that the lower-dimensional ridges occur twice, except at tips.
         if mg.dim >= 2:
-            assert mg.ridge_peaks.nnz == 2 * (frac_sd.num_nodes - num_tip_nodes)
+            sums = np.sum(np.abs(mg.ridge_peaks), axis=0)
+            assert np.allclose(sums[sd_down.tags["tip_nodes"]], 0)
+            assert np.allclose(sums[~sd_down.tags["tip_nodes"]], 2)
 
 
 def test_mdg_3d_itsc(_mdg_dict):

--- a/tests/grids/test_grid_ridges.py
+++ b/tests/grids/test_grid_ridges.py
@@ -110,3 +110,7 @@ def test_mdg_3d_itsc(_mdg_dict):
     for mg in mdg.interfaces(dim=1):
         assert mg.ridge_peaks.shape == (0, 0)
         assert mg.face_ridges.shape == (20, 2)
+
+    for mg in mdg.interfaces(dim=2):
+        assert mg.ridge_peaks.shape == (112, 20)
+        assert mg.face_ridges.shape == (392, 32)

--- a/tests/grids/test_grid_ridges.py
+++ b/tests/grids/test_grid_ridges.py
@@ -87,17 +87,18 @@ def test_mdg_2d(mdg_embedded_frac_2d):
     assert (mg.face_ridges - known_face_ridges()).nnz == 0
 
 
-def test_mdg_3d(_mdg_dict):
-    mdg = _mdg_dict["embedded_frac_3D"]
-    mg = mdg.interfaces()[0]
+def test_mdg_3d(mdg):
+    for mg in mdg.interfaces():
+        frac_sd = mg.sd_pair[1]
+        num_tip_nodes = frac_sd.tags["tip_nodes"].sum()
 
-    frac_sd = mdg.subdomains()[1]
-    num_tip_nodes = frac_sd.tags["tip_nodes"].sum()
+        # Check that the lower-dimensional faces occur twice
+        if mg.dim >= 1:
+            assert mg.face_ridges.nnz == 2 * (frac_sd.num_faces - num_tip_nodes)
 
-    assert mg.ridge_peaks.nnz == 2 * (frac_sd.num_nodes - num_tip_nodes)
-
-    # TODO: Find bug in the ridge computation so that the following assertion holds
-    assert mg.face_ridges.nnz == 2 * (frac_sd.num_faces - num_tip_nodes)
+        # Check that the lower-dimensional ridges occur twice
+        if mg.dim >= 2:
+            assert mg.ridge_peaks.nnz == 2 * (frac_sd.num_nodes - num_tip_nodes)
 
 
 def test_mdg_3d_itsc(_mdg_dict):


### PR DESCRIPTION
There was a bug in the ridge computation where the number of non-zeros did not match up with what was expected. I'm not sure if the new meshing of pp fixed it, but I was not able to reproduce it.

This PR updates the ridge computations on the mortar grid to use the newly introduced `sd.rotation_matrix` instead of recomputing it. It moreover pulls some silly computations out of the for-loop to remove redundancy.

Closes #229 