### PR TITLE
Convert remaining fvm docstring formulas to LaTeX

### DIFF
--- a/src/pygeon/discretizations/fvm/boundary_conditions.py
+++ b/src/pygeon/discretizations/fvm/boundary_conditions.py
@@ -131,7 +131,10 @@ class ElasticityBC(FiniteVolumeBC):
         r"""
         Set spring boundary conditions, cf. Appendix A2.21 in Nordbotten and
         Keilegavlen (2025), https://doi.org/10.1016/j.camwa.2025.07.035:
-        $n \cdot \sigma = 2 / \mathrm{dists} \,(u_0 - u)$.
+
+        .. math::
+
+            n \cdot \sigma = \frac{2}{\text{dists}} (u_0 - u)
 
         Args:
             dists (np.ndarray): Weighted distance (inverse spring constant).
@@ -197,7 +200,10 @@ class FlowBC(FiniteVolumeBC):
     ) -> None:
         r"""
         Set Robin boundary conditions:
-        $n \cdot q = (p - p_0) / \mathrm{dists}$.
+
+        .. math::
+
+            n \cdot q = \frac{p - p_0}{\text{dists}}
 
         Args:
             dists (np.ndarray): Weighted distance (inverse permeability).

--- a/src/pygeon/discretizations/fvm/fvm_disc.py
+++ b/src/pygeon/discretizations/fvm/fvm_disc.py
@@ -113,8 +113,14 @@ class FiniteVolumeDiscretization(abc.ABC):
 
     def compute_harmonic_avg(self, faces: np.ndarray, dists: np.ndarray) -> np.ndarray:
         r"""
-        Compute $(1 / \delta_i + 1 / \delta_j)^{-1}$ at each face, between cells i and
-        j. This is used to compute the effective permeability at the face.
+        Compute the harmonic average
+
+        .. math::
+
+            \left(\frac{1}{\delta_i} + \frac{1}{\delta_j}\right)^{-1}
+
+        at each face, between cells :math:`i` and :math:`j`. This is used to compute
+        the effective permeability at the face.
 
         Args:
             faces (np.ndarray): The extended array of faces.

--- a/src/pygeon/discretizations/fvm/tpfa.py
+++ b/src/pygeon/discretizations/fvm/tpfa.py
@@ -122,9 +122,10 @@ class TPFA(pg.FiniteVolumeDiscretization):
     def compute_weighted_dists(
         self, sd: pg.Grid, data: dict | None, find_cell_faces: Tuple
     ) -> np.ndarray:
-        """
-        Compute delta_k^i / normal_perm for every physical face-cell pair. Boundary
-        conditions are handled later.
+        r"""
+        Compute :math:`\delta_k^i / \kappa_{nn}^i` for every physical face-cell pair
+        :math:`(k, i)`, where :math:`\kappa_{nn}^i` is the normal-normal component of
+        the permeability tensor. Boundary conditions are handled later.
 
         Args:
             sd (pg.Grid): Grid, or a subclass.

--- a/src/pygeon/discretizations/fvm/tpsa.py
+++ b/src/pygeon/discretizations/fvm/tpsa.py
@@ -161,9 +161,9 @@ class TPSA(pg.FiniteVolumeDiscretization):
     def compute_weighted_dists(
         self, sd: pg.Grid, data: dict | None, find_cell_faces: Tuple
     ) -> np.ndarray:
-        """
-        Computes delta_k^i / mu_i from (2.1) for every physical face-cell pair (k, i).
-        Boundary conditions are handled later.
+        r"""
+        Computes :math:`\delta_k^i / \mu_i` from (2.1) for every physical face-cell
+        pair :math:`(k, i)`. Boundary conditions are handled later.
 
         Args:
             sd (pg.Grid): Grid, or a subclass.
@@ -225,16 +225,22 @@ class TPSA(pg.FiniteVolumeDiscretization):
 
     def compute_delta_mu_k(self, faces: np.ndarray, dists: np.ndarray) -> np.ndarray:
         r"""
-        Compute the delta^mu_k of (3.5) given by
-        0.5 * ( mu_i delta_k^-i + mu_j delta_k^-j)^-1
-        for each face k with neighboring cells (i,j).
+        Compute :math:`\delta_k^\mu` of (3.5), given by
+
+        .. math::
+
+            \delta_k^\mu = \frac{1}{2} \left(
+                \mu_i \left(\delta_k^i\right)^{-1} + \mu_j \left(\delta_k^j\right)^{-1}
+            \right)^{-1}
+
+        for each face :math:`k` with neighboring cells :math:`(i, j)`.
 
         Args:
             faces (np.ndarray): The extended array of faces.
             dists (np.ndarray): The extended array of weighted distances.
 
         Returns:
-            np.ndarray: The array of $\delta_k^\mu$.
+            np.ndarray: The array of :math:`\delta_k^\mu`.
         """
         # Compute the reciprocal
         inv_dists = np.empty_like(dists)
@@ -253,15 +259,21 @@ class TPSA(pg.FiniteVolumeDiscretization):
 
     def compute_harmonic_avg(self, faces: np.ndarray, dists: np.ndarray) -> np.ndarray:
         r"""
-        Compute the harmonic average of mu from (3.5), divided by delta_k, at each face:
-        mu_effective = ( delta_k^i / mu_i + delta_k^j / mu_j)^-1
+        Compute the harmonic average of :math:`\mu` from (3.5), divided by
+        :math:`\delta_k`, at each face:
+
+        .. math::
+
+            \mu_{\text{eff}} = \left(
+                \frac{\delta_k^i}{\mu_i} + \frac{\delta_k^j}{\mu_j}
+            \right)^{-1}
 
         Args:
             faces (np.ndarray): The extended array of faces.
             dists (np.ndarray): The extended array of weighted distances.
 
         Returns:
-            np.ndarray: The face-wise harmonic average of $\mu$.
+            np.ndarray: The face-wise harmonic average of :math:`\mu`.
         """
         output_list = [1 / np.bincount(faces, weights=row) for row in dists]
         return np.array(output_list)
@@ -420,8 +432,8 @@ class TPSA(pg.FiniteVolumeDiscretization):
         return Xi
 
     def convert_to_xi_tilde_inplace(self, Xi: list) -> list:
-        """
-        Compute the complementary averaging operator Xi_tilde from (2.6).
+        r"""
+        Compute the complementary averaging operator :math:`\tilde{\Xi}` from (2.6).
         NOTE: This is an in-place operation.
 
         Args:


### PR DESCRIPTION
Several math expressions in the fvm module were written as plain text or with $...$ delimiters instead of the :math:/.. math:: roles used elsewhere in the codebase. Unifies the style and adds raw-string prefixes where needed.