### PR TITLE
Fix Sphinx doc build warnings and errors

### DIFF
--- a/docs/api/grids.rst
+++ b/docs/api/grids.rst
@@ -21,3 +21,4 @@ Submodules
    pygeon.grids.levelset_remesh
    pygeon.grids.create_grid
    pygeon.grids.refinement
+   pygeon.grids.regularizers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,6 @@ autodoc_default_options = {
     "special-members": "__init__",
     "undoc-members": True,
     "exclude-members": "__weakref__",
-    "no-index": True,
 }
 
 autodoc_typehints = "none"

--- a/src/pygeon/discretizations/fvm/tpsa.py
+++ b/src/pygeon/discretizations/fvm/tpsa.py
@@ -18,10 +18,11 @@ class TPSA(pg.FiniteVolumeDiscretization):
 
     Our implementation differs from Porepy (v1.13) in the imposition of boundary
     conditions. In particular, we made the following changes:
-        - The order of R and Xi_tilde in the [0, 1] block of (A.2.25)
-        - The order of n and Xi_tilde in the [0, 2] block of (A.2.25)
-        - Changed "delta R^2" to "R delta R" in the [1, 1] block of (A.2.25)
-        - Used the delta^mu_k in the normal direction in the [2, 2] block of (A.2.25)
+
+    - The order of R and Xi_tilde in the [0, 1] block of (A.2.25)
+    - The order of n and Xi_tilde in the [0, 2] block of (A.2.25)
+    - Changed "delta R^2" to "R delta R" in the [1, 1] block of (A.2.25)
+    - Used the delta^mu_k in the normal direction in the [2, 2] block of (A.2.25)
 
     These adaptations are necessary for consistency with rolling boundary conditions.
     We moreover used signed distances between face and cell centers.


### PR DESCRIPTION
- Remove global "no-index" autodoc default, which prevented every :meth:/:attr: cross-reference in the codebase from resolving.
- Fix RST indentation in the TPSA class docstring bullet list, which docutils flagged as an unexpected-indentation error.
- Add the missing pygeon.grids.regularizers entry to the grids API toctree.

Verified locally with the same sphinx-build -W -n --keep-going invocation used in CI: 14 warnings/errors -> 0.