### PR TITLE
Remove redundant compute_geometry

### DIFF
--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -56,7 +56,10 @@ class Grid(pp.Grid):
         Returns:
             None
         """
-        super().compute_geometry()
+        # We only invoke the porepy routine if it hasn't already been computed.
+        if "Compute geometry" not in self.history:
+            super().compute_geometry()
+
         self.compute_rotation_matrix()
         self.compute_ridges()
 

--- a/src/pygeon/grids/grid.py
+++ b/src/pygeon/grids/grid.py
@@ -46,9 +46,9 @@ class Grid(pp.Grid):
         2: "ridges"
         3: "peaks"
 
-        This method computes the geometry of the grid by calling the
-        superclass's compute_geometry method, computing the ridge
-        and peak connectivities, and storing the edge lengths and mesh size.
+        This method computes the geometry of the grid by calling the superclass's
+        compute_geometry method if this has not been happened before, computing the
+        ridge and peak connectivities, and storing the edge lengths and mesh size.
 
         Args:
             None

--- a/src/pygeon/grids/regularizers.py
+++ b/src/pygeon/grids/regularizers.py
@@ -59,7 +59,7 @@ def graph_laplace_regularization(sd: pg.Grid, sliding: bool = True) -> pg.Grid:
 
     ess = np.tile(sd.tags["domain_boundary_nodes"], sd.dim)
     u = compute_displacement(sd, A, b, sd.nodes, None if sliding else ess)
-    return update_grid(sd, u)
+    return create_displaced_grid(sd, u)
 
 
 def graph_laplace_dual_regularization(
@@ -111,9 +111,7 @@ def graph_laplace_dual_regularization(
     cell_centers = centers[: sd.dim] + u
 
     # build a voronoi grid based on the new cell centers
-    sd = pg.VoronoiGrid(vrt=cell_centers)
-    sd.compute_geometry()
-    return sd
+    return pg.VoronoiGrid(vrt=cell_centers)
 
 
 def elasticity_regularization(
@@ -121,7 +119,7 @@ def elasticity_regularization(
 ) -> pg.Grid:
     """
     Regularize the grid using the elasticity regularization. The topology of the grid is
-    preserved.
+    preserved, but geometry is not recomputed.
 
     Args:
         sd (pg.Grid): The grid to regularize.
@@ -146,7 +144,7 @@ def elasticity_regularization(
 
     ess = np.tile(sd.tags["domain_boundary_nodes"], sd.dim)
     u = compute_displacement(sd, A, b, sd.nodes, None if sliding else ess)
-    return update_grid(sd, u)
+    return create_displaced_grid(sd, u)
 
 
 def compute_displacement(
@@ -189,19 +187,17 @@ def compute_displacement(
     return u.reshape((sd.dim, -1))
 
 
-def update_grid(sd: pg.Grid, u: np.ndarray) -> pg.Grid:
+def create_displaced_grid(sd: pg.Grid, u: np.ndarray) -> pg.Grid:
     """
-    Update the grid with the displacement field by modifiying the node coordinates.
+    Move the nodes according to a displacement field. The geometry is not recomputed.
 
     Args:
-        sd (pg.Grid): The grid to update.
+        sd (pg.Grid): The grid to displace.
         u (np.ndarray): The displacement field.
 
     Returns:
-        The updated grid.
+        The displaced grid.
     """
-    # Update the grid
-    sd = sd.copy()
-    sd.nodes[: sd.dim, :] += u
-    sd.compute_geometry()
-    return sd
+    nodes = sd.nodes.copy()
+    nodes[: sd.dim, :] += u
+    return pg.Grid(sd.dim, nodes, sd.face_nodes, sd.cell_faces, sd.name)

--- a/tests/grids/test_regularizers.py
+++ b/tests/grids/test_regularizers.py
@@ -29,6 +29,7 @@ def test_lloyd(sd_voronoi):
 
 def test_graph_laplace(sd_voronoi):
     sd = pg.graph_laplace_regularization(sd_voronoi)
+    sd.compute_geometry()
 
     # Topology is preserved
     assert (sd.face_ridges - sd_voronoi.face_ridges).nnz == 0
@@ -40,6 +41,7 @@ def test_graph_laplace(sd_voronoi):
 
 def test_graph_laplace_cart_grids(unit_cart_sd):
     sd = pg.graph_laplace_regularization(unit_cart_sd, False)
+    sd.compute_geometry()
 
     # The regularization leaves regular Cartesian grids intact
     assert np.allclose(sd.nodes, unit_cart_sd.nodes)
@@ -48,6 +50,7 @@ def test_graph_laplace_cart_grids(unit_cart_sd):
 
 def test_graph_laplace_dual(sd_voronoi):
     sd = pg.graph_laplace_dual_regularization(sd_voronoi)
+    sd.compute_geometry()
 
     # Aspect ratios have improved
     assert aspect_ratio(sd) < aspect_ratio(sd_voronoi)
@@ -55,6 +58,7 @@ def test_graph_laplace_dual(sd_voronoi):
 
 def test_elasticity_regulatization(sd_voronoi):
     sd = pg.elasticity_regularization(sd_voronoi, 10, sliding=False)
+    sd.compute_geometry()
 
     # Aspect ratios have improved
     assert aspect_ratio(sd) < aspect_ratio(sd_voronoi)


### PR DESCRIPTION
If a grid was constructed using `pg.unit_grid` or any other function that invokes `pp.meshing.subdomains_to_mdg`, then the grid has already gone through the porepy `compute_geometry` routine. We can skip a recomputation by looking into the grid's history log.