### PR TITLE
Add keepalive workflow to prevent scheduled workflows from being auto-disabled

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,56 @@
+# GitHub automatically disables scheduled workflows (like the nightly
+# Pytest run in run-pytest.yml) after 60 days without repository
+# activity -- there is no setting to opt out of this. This workflow makes
+# a trivial commit well before that deadline, which resets the inactivity
+# clock for the whole repo and keeps the real schedules running even
+# during quiet stretches with no pushes or PRs.
+#
+# It only commits when the repo has genuinely been quiet: if the last
+# commit (real or a previous keepalive one) is under 30 days old, it's a
+# no-op, so active development produces zero extra noise.
+name: Keepalive Workflow
+
+on:
+  schedule:
+    - cron: "0 2 1 * *" # once a month
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  keepalive-job:
+    name: Keepalive Workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check days since last commit
+        id: check
+        run: |
+          last_commit_epoch=$(git log -1 --format=%ct)
+          now_epoch=$(date +%s)
+          days_since=$(( (now_epoch - last_commit_epoch) / 86400 ))
+          echo "Days since last commit: $days_since"
+          if [ "$days_since" -ge 30 ]; then
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record a keepalive timestamp
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          mkdir -p .github
+          date -u +"Last keepalive run: %Y-%m-%dT%H:%M:%SZ" > .github/keepalive.txt
+
+      - name: Commit and push
+        if: steps.check.outputs.needed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f .github/keepalive.txt
+          git commit -m "chore: keepalive commit to prevent scheduled workflows from being disabled"
+          git push


### PR DESCRIPTION
## Why

GitHub automatically disables *scheduled* workflows (the `schedule:` trigger, e.g. `run-pytest.yml`'s nightly cron) after 60 days with no repository activity — pushes, merges, etc. There's no setting to opt out of this; it's a hard platform policy.

This bit us on a sibling course repo ([lab_numgeo](https://github.com/compgeo-mox/lab_numgeo)): its nightly "Check tutorials" workflow had been silently disabled since February because the repo went quiet between semesters, so its passing badge was actually ~7 months stale and hadn't caught any drift in that whole time. pygeon's own nightly Pytest run is exposed to the same failure mode during any release lull, conference travel, etc. — it would just go quiet with no warning, and nobody would notice until something had already broken further than necessary.

## What this does

Adds `.github/workflows/keepalive.yml`, which runs monthly and makes a small commit *only if* the repo's last commit is 30+ days old — during normal development (regular pushes/PRs) it's a complete no-op and adds zero noise. It only actually fires during a genuinely quiet stretch, resetting GitHub's 60-day clock so the real scheduled workflows keep running.

Plain git rather than a marketplace action, to avoid depending on any third-party action / needing to adjust Actions permissions.

## Test plan

- [x] Verified the equivalent workflow in lab_numgeo: fires and commits correctly when the repo is quiet, and correctly no-ops (skips the commit) when there's been recent activity.
- [ ] After merge, trigger manually once via `workflow_dispatch` to confirm it runs cleanly in this repo's environment too.