### PR TITLE
Vectorize interpolation and natural bcs

### DIFF
--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -223,7 +223,8 @@ class Discretization(abc.ABC):
             case 0:  # Scalar valued
                 return np.tile(interp, coords.shape[1])
             case 1:  # Vector valued
-                return np.tile(interp, (coords.shape[1], 1)).T
+                if interp.shape[0] == 3:
+                    return np.tile(interp, (coords.shape[1], 1)).T
 
         raise RuntimeError(
             "Vectorize func(x) so that it can be evaluated for multiple columns of x."

--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -201,8 +201,8 @@ class Discretization(abc.ABC):
         self, func: Callable[[np.ndarray], np.ndarray], coords: np.ndarray
     ) -> np.ndarray:
         """
-        Interpolates a function at given coordinates. We assume that the function is
-        vectorized so that func(x) can be evaluated for all columns of x.
+        Interpolates a function at given coordinates. We assume that func(x) rapidly
+        evaluates the given function for all coordinates in the columns of x.
 
         Args:
             func (Callable): A function that returns the function values at coordinates.

--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -197,6 +197,32 @@ class Discretization(abc.ABC):
             np.ndarray: The values of the degrees of freedom
         """
 
+    def eval_func_at_coords(
+        self, func: Callable[[np.ndarray], np.ndarray], coords: np.ndarray
+    ) -> np.ndarray:
+        """
+        Interpolates a function at given coordinates. If the function is constant
+
+        Args:
+            sd (pg.Grid): Grid, or a subclass.
+            func (Callable): A function that returns the function values at coordinates.
+
+        Returns:
+            np.ndarray: The values of the degrees of freedom
+        """
+        interp = np.asarray(func(coords))
+
+        if interp.ndim > 0 and interp.shape[-1] == coords.shape[-1]:
+            return interp
+
+        match interp.ndim:
+            case 0:
+                return np.full(coords.shape[1], interp)
+            case 1:
+                return np.tile(interp, (coords.shape[1], 1)).T
+            case _:
+                raise RuntimeError
+
     def eval_at_cell_centers(self, sd: pg.Grid) -> sps.csc_array:
         """
         Assembles the matrix for evaluating the discretization at the cell centers.

--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -223,11 +223,12 @@ class Discretization(abc.ABC):
             case 0:  # Scalar valued
                 return np.tile(interp, coords.shape[1])
             case 1:  # Vector valued
-                if interp.shape[0] == 3:
+                if interp.shape[0] == pg.AMBIENT_DIM:
                     return np.tile(interp, (coords.shape[1], 1)).T
 
         raise RuntimeError(
-            "Vectorize func(x) so that it can be evaluated for multiple columns of x."
+            "Vectorize the function so that it can be evaluated for multiple columns"
+            + " of the input array."
         )
 
     def eval_at_cell_centers(self, sd: pg.Grid) -> sps.csc_array:

--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -220,8 +220,8 @@ class Discretization(abc.ABC):
                 return np.full(coords.shape[1], interp)
             case 1:
                 return np.tile(interp, (coords.shape[1], 1)).T
-            case _:
-                raise RuntimeError
+
+        raise RuntimeError
 
     def eval_at_cell_centers(self, sd: pg.Grid) -> sps.csc_array:
         """

--- a/src/pygeon/discretizations/discretization.py
+++ b/src/pygeon/discretizations/discretization.py
@@ -201,27 +201,33 @@ class Discretization(abc.ABC):
         self, func: Callable[[np.ndarray], np.ndarray], coords: np.ndarray
     ) -> np.ndarray:
         """
-        Interpolates a function at given coordinates. If the function is constant
+        Interpolates a function at given coordinates. We assume that the function is
+        vectorized so that func(x) can be evaluated for all columns of x.
 
         Args:
-            sd (pg.Grid): Grid, or a subclass.
             func (Callable): A function that returns the function values at coordinates.
+            coords (np.ndarray): A coordinate array with shape (3, n).
 
         Returns:
             np.ndarray: The values of the degrees of freedom
         """
         interp = np.asarray(func(coords))
 
+        # If the function is properly vectorized, it returns an array with the last axis
+        # indexing the evaluation points.
         if interp.ndim > 0 and interp.shape[-1] == coords.shape[-1]:
             return interp
 
+        # For constant functions, we populate the array ourselves.
         match interp.ndim:
-            case 0:
-                return np.full(coords.shape[1], interp)
-            case 1:
+            case 0:  # Scalar valued
+                return np.tile(interp, coords.shape[1])
+            case 1:  # Vector valued
                 return np.tile(interp, (coords.shape[1], 1)).T
 
-        raise RuntimeError
+        raise RuntimeError(
+            "Vectorize func(x) so that it can be evaluated for multiple columns of x."
+        )
 
     def eval_at_cell_centers(self, sd: pg.Grid) -> sps.csc_array:
         """

--- a/src/pygeon/discretizations/fem/h1.py
+++ b/src/pygeon/discretizations/fem/h1.py
@@ -267,7 +267,11 @@ class Lagrange1(pg.Discretization):
             np.ndarray: An array containing the interpolated values at each node of the
             grid.
         """
-        return np.array([func(x) for x in sd.nodes.T])
+        interp = func(sd.nodes)
+        if np.asarray(interp).size == 1:
+            return np.full(self.ndof(sd), interp)
+        else:
+            return interp
 
     def assemble_nat_bc(
         self, sd: pg.Grid, func: Callable[[np.ndarray], np.ndarray], b_faces: np.ndarray

--- a/src/pygeon/discretizations/fem/h1.py
+++ b/src/pygeon/discretizations/fem/h1.py
@@ -267,11 +267,7 @@ class Lagrange1(pg.Discretization):
             np.ndarray: An array containing the interpolated values at each node of the
             grid.
         """
-        interp = func(sd.nodes)
-        if np.asarray(interp).size == 1:
-            return np.full(self.ndof(sd), interp)
-        else:
-            return interp
+        return self.eval_func_at_coords(func, sd.nodes)
 
     def assemble_nat_bc(
         self, sd: pg.Grid, func: Callable[[np.ndarray], np.ndarray], b_faces: np.ndarray
@@ -511,7 +507,7 @@ class Lagrange2(pg.Discretization):
 
         coords = np.hstack((sd.nodes, edge_coords))
 
-        return np.array([func(x) for x in coords.T])
+        return self.eval_func_at_coords(func, coords)
 
     def assemble_nat_bc(
         self, sd: pg.Grid, func: Callable[[np.ndarray], np.ndarray], b_faces: np.ndarray

--- a/src/pygeon/discretizations/fem/hcurl.py
+++ b/src/pygeon/discretizations/fem/hcurl.py
@@ -158,12 +158,11 @@ class Nedelec0(pg.Discretization):
         Returns:
             np.ndarray: The interpolated values on the grid.
         """
-        tangents = sd.edge_tangents
         midpoints = sd.nodes @ abs(sd.ridge_peaks) / 2
-        vals = [
-            np.inner(func(x).flatten(), t) for (x, t) in zip(midpoints.T, tangents.T)
-        ]
-        return np.array(vals)
+        func_vals = self.eval_func_at_coords(func, midpoints)
+        vals = (func_vals * sd.edge_tangents).sum(axis=0)
+
+        return vals
 
     def proj_to_Ne1(self, sd: pg.Grid) -> sps.csc_array:
         r"""
@@ -343,13 +342,12 @@ class Nedelec1(pg.Discretization):
         Returns:
             np.ndarray: The interpolated values.
         """
-        vals = np.zeros(self.ndof(sd))
-        for r in np.arange(sd.num_edges):
-            loc = slice(sd.ridge_peaks.indptr[r], sd.ridge_peaks.indptr[r + 1])
-            peaks = sd.ridge_peaks.indices[loc]
-            t = sd.edge_tangents[:, r]
-            vals[r] = np.inner(func(sd.nodes[:, peaks[0]]).flatten(), t)
-            vals[r + sd.num_edges] = np.inner(func(sd.nodes[:, peaks[1]]).flatten(), -t)
+        edge_nodes = np.reshape(sd.ridge_peaks.indices, (-1, 2))
+        coords = sd.nodes[:, edge_nodes.ravel(order="F")]
+        func_vals = self.eval_func_at_coords(func, coords)
+
+        tangents = np.hstack((sd.edge_tangents, -sd.edge_tangents))
+        vals = (func_vals * tangents).sum(axis=0)
 
         return vals
 

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -364,14 +364,12 @@ class BDM1(pg.Discretization):
         Returns:
             np.ndarray: The interpolated values on the grid.
         """
-        vals = np.zeros(self.ndof(sd))
+        loc_nodes = np.reshape(sd.face_nodes.indices, (sd.num_faces, -1))
+        coords = sd.nodes[:, loc_nodes.ravel(order="F")]
+        func_vals = self.eval_func_at_coords(func, coords)
 
-        for face in np.arange(sd.num_faces):
-            func_loc = np.array(
-                [func(sd.nodes[:, node]) for node in sd.face_nodes[:, [face]].indices]
-            ).T
-            vals_loc = sd.face_normals[:, face] @ func_loc
-            vals[face + np.arange(sd.dim) * sd.num_faces] = vals_loc
+        normals = np.tile(sd.face_normals, sd.dim)
+        vals = (func_vals * normals).sum(axis=0)
 
         return vals
 
@@ -710,6 +708,8 @@ class RT1(pg.Discretization):
         interp_cells = np.zeros(sd.dim * sd.num_cells)
         cell_nodes = sd.cell_nodes()
 
+        func_at_centers = self.eval_func_at_coords(func, sd.cell_centers)
+
         for c in range(sd.num_cells):
             loc = slice(cell_nodes.indptr[c], cell_nodes.indptr[c + 1])
             nodes_loc = cell_nodes.indices[loc]
@@ -717,12 +717,11 @@ class RT1(pg.Discretization):
             basis_at_center = self.eval_basis_functions_at_center(
                 sd, nodes_loc, sd.cell_volumes[c]
             )
-            func_at_center = func(sd.cell_centers[:, c])
 
             # Compute the coefficients c_i such
             # that sum_i c_i phi_i = f at the cell center
             coefficients = np.linalg.solve(
-                basis_at_center[: sd.dim, :], func_at_center[: sd.dim]
+                basis_at_center[: sd.dim, :], func_at_centers[: sd.dim, c]
             )
 
             interp_cells[sd.num_cells * np.arange(sd.dim) + c] = coefficients

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -205,11 +205,10 @@ class RT0(pg.Discretization):
         Returns:
             np.ndarray: The values of the degrees of freedom.
         """
-        vals = [
-            np.inner(func(x).flatten(), normal)
-            for (x, normal) in zip(sd.face_centers.T, sd.face_normals.T)
-        ]
-        return np.array(vals)
+        func_vals = self.eval_func_at_coords(func, sd.face_centers)
+        vals = (func_vals * sd.face_normals).sum(axis=0)
+
+        return vals
 
     def assemble_nat_bc(
         self, sd: pg.Grid, func: Callable[[np.ndarray], np.ndarray], b_faces: np.ndarray

--- a/src/pygeon/discretizations/fem/hdiv.py
+++ b/src/pygeon/discretizations/fem/hdiv.py
@@ -233,10 +233,8 @@ class RT0(pg.Discretization):
 
         vals = np.zeros(self.ndof(sd))
 
-        for dof in b_faces:
-            vals[dof] = (
-                func(sd.face_centers[:, dof]) * sd.cell_faces.tocsr()[dof, :].sum()
-            )
+        signs = sd.cell_faces.sum(axis=1)[b_faces]
+        vals[b_faces] = signs * func(sd.face_centers[:, b_faces])
 
         return vals
 

--- a/src/pygeon/discretizations/fem/l2.py
+++ b/src/pygeon/discretizations/fem/l2.py
@@ -896,23 +896,20 @@ class PwQuadratics(PwPolynomials):
         edge_nodes = self.get_local_edge_nodes(sd.dim)
 
         cell_nodes = sd.cell_nodes()
-        vals = np.empty((sd.num_cells, self.ndof_per_cell(sd)))
+        nodes_per_cell = np.reshape(cell_nodes.indices, (sd.num_cells, -1))
 
-        for c in range(sd.num_cells):
-            loc = slice(cell_nodes.indptr[c], cell_nodes.indptr[c + 1])
-            nodes_loc = cell_nodes.indices[loc]
+        coord_list = [sd.nodes[:, nodes_per_cell.ravel(order="F")]]
 
-            vals[c, : sd.dim + 1] = [func(x) for x in sd.nodes[:, nodes_loc].T]
+        for edge in edge_nodes:
+            edge_coord = (
+                sd.nodes[:, nodes_per_cell[:, edge[0]]]
+                + sd.nodes[:, nodes_per_cell[:, edge[1]]]
+            ) / 2
+            coord_list.append(edge_coord)
 
-            edge_nodes_loc = nodes_loc[edge_nodes]
-            edge_mid_pt = (
-                sd.nodes[:, edge_nodes_loc[:, 0]] + sd.nodes[:, edge_nodes_loc[:, 1]]
-            )
-            edge_mid_pt /= 2
+        coords = np.hstack(coord_list)
 
-            vals[c, sd.dim + 1 :] = [func(x) for x in edge_mid_pt.T]
-
-        return vals.ravel(order="F")
+        return self.eval_func_at_coords(func, coords)
 
     def proj_to_higher_PwPolynomials(self, sd: pg.Grid) -> sps.csc_array:
         r"""

--- a/src/pygeon/discretizations/fem/l2.py
+++ b/src/pygeon/discretizations/fem/l2.py
@@ -404,9 +404,8 @@ class PwConstants(PwPolynomials):
         Returns:
             np.ndarray: The values of the degrees of freedom.
         """
-        return np.array(
-            [func(x) * vol for (x, vol) in zip(sd.cell_centers.T, sd.cell_volumes)]
-        )
+        vals = self.eval_func_at_coords(func, sd.cell_centers)
+        return vals * sd.cell_volumes
 
     def proj_to_higher_PwPolynomials(self, sd: pg.Grid) -> sps.csc_array:
         r"""
@@ -527,7 +526,7 @@ class PwLinears(PwPolynomials):
         gauss_pts = alpha * sd.nodes[:, nodes] + (1 - alpha) * sd.cell_centers[:, cells]
 
         # Evaluate the function at the Gauss points.
-        func_at_gauss = np.array([func(x) for x in gauss_pts.T])
+        func_at_gauss = self.eval_func_at_coords(func, gauss_pts)
 
         # To retrieve the values at the nodes, we first compute the value of the
         # interpolated function at the cell center. Since the Gauss points are

--- a/src/pygeon/discretizations/fem/vec_l2.py
+++ b/src/pygeon/discretizations/fem/vec_l2.py
@@ -139,7 +139,8 @@ class VecPwPolynomials(pg.VecDiscretization):
             np.ndarray: The values of the degrees of freedom
         """
         # If the mesh is tilted, then the 3-vector from func needs to be rotated.
-        rotated_func = lambda x: sd.rotation_matrix @ func(x)
+        rotated_func = lambda x: np.einsum("ij,j...->i...", sd.rotation_matrix, func(x))
+
         return super().interpolate(sd, rotated_func)
 
     def local_dofs_of_cell(

--- a/tests/discretizations/fem/hdiv/test_rt0.py
+++ b/tests/discretizations/fem/hdiv/test_rt0.py
@@ -149,7 +149,7 @@ def test_range_discr_class(discr):
 
 def test_error_l2(discr, unit_sd):
     def fun(pt):
-        return np.array([pt[0] ** 2 + 2 * pt[1], 2 * pt[0] + pt[1], 0])
+        return np.array([pt[0] ** 2 + 2 * pt[1], 2 * pt[0] + pt[1], 0 * pt[0]])
 
     int_sol = discr.interpolate(unit_sd, fun)
 

--- a/tests/discretizations/fem/l2/test_l2.py
+++ b/tests/discretizations/fem/l2/test_l2.py
@@ -80,11 +80,16 @@ def test_interpolate_and_evaluate(discr: pg.Discretization, unit_sd: pg.Grid):
         case 2:
 
             def func(x):
-                ans = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
-                ans[: unit_sd.dim, : unit_sd.dim] = np.tile(
-                    x[: unit_sd.dim], (unit_sd.dim, 1)
-                )
-                return ans + ans.T  # Make it symmetric for the SymMat case
+                d = unit_sd.dim
+                ans = np.tile(x, [3, 1, 1][: x.ndim + 1])
+                ans[d:] = 0
+                ans[:, d:] = 0
+
+                # Make it symmetric for the SymMat case
+                if "Sym" in type(discr).__name__:
+                    ans += np.transpose(ans, [1, 0, 2][: x.ndim + 1])
+
+                return ans
 
     known_vals = np.vstack([func(x).ravel() for x in unit_sd.cell_centers.T]).T
 

--- a/tests/discretizations/fem/l2/test_l2.py
+++ b/tests/discretizations/fem/l2/test_l2.py
@@ -74,8 +74,8 @@ def test_interpolate_and_evaluate(discr: pg.Discretization, unit_sd: pg.Grid):
         case 1:
 
             def func(x):
-                ans = np.zeros(pg.AMBIENT_DIM)
-                ans[: unit_sd.dim] = x[: unit_sd.dim]
+                ans = x.copy()
+                ans[unit_sd.dim :] = 0
                 return ans
         case 2:
 

--- a/tests/discretizations/fem/l2/test_pwlinear.py
+++ b/tests/discretizations/fem/l2/test_pwlinear.py
@@ -76,7 +76,7 @@ def test_interpolate(discr, unit_sd):
 
 def test_interpolate_heaviside(discr, unit_sd_1d):
     def heaviside(x):
-        return 0 if x[0] < 0.5 else 1
+        return x[0] >= 0.5
 
     true_norm_squared = 0.5
     mass = discr.assemble_mass_matrix(unit_sd_1d)

--- a/tests/discretizations/fem/l2/test_pwlinear.py
+++ b/tests/discretizations/fem/l2/test_pwlinear.py
@@ -96,7 +96,7 @@ def test_proj_to_lower_PwPolynomials(discr, unit_sd):
     P0 = pg.PwConstants()
 
     Proj = discr.proj_to_lower_PwPolynomials(unit_sd)
-    fun_P1 = discr.interpolate(unit_sd, lambda x: np.sum(x))
-    fun_P0 = P0.interpolate(unit_sd, lambda x: np.sum(x))
+    fun_P1 = discr.interpolate(unit_sd, lambda x: np.sum(x, axis=0))
+    fun_P0 = P0.interpolate(unit_sd, lambda x: np.sum(x, axis=0))
 
     assert np.allclose(Proj @ fun_P1, fun_P0)

--- a/tests/discretizations/fem/mat_l2/test_matl2.py
+++ b/tests/discretizations/fem/mat_l2/test_matl2.py
@@ -36,7 +36,7 @@ def test_assemble_upper_convected_distortion(mat_discr, ref_sd):
         return grad_full
 
     def mat_func(x):
-        mat = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
+        mat = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM, x.shape[-1]))
         mat[0, 0] = 1 + 2 * x[0]
 
         if dim >= 2:
@@ -54,10 +54,13 @@ def test_assemble_upper_convected_distortion(mat_discr, ref_sd):
         return mat
 
     def distortion_func(x):
-        mat = mat_func(x)[:dim, :dim]
-        distortion = -(grad_block @ mat + mat @ grad_block.T)
+        mat = mat_func(x)[:dim, :dim]  # (d, d, n)
 
-        val = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
+        mat_shift = np.moveaxis(mat, -1, 0)
+        distortion = -(grad_block @ mat_shift + mat_shift @ grad_block.T)
+        distortion = np.moveaxis(distortion, 0, -1)
+
+        val = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM, x.shape[-1]))
         val[:dim, :dim] = distortion
         return val
 

--- a/tests/discretizations/fem/mat_l2/test_matpwlinears.py
+++ b/tests/discretizations/fem/mat_l2/test_matpwlinears.py
@@ -18,7 +18,7 @@ def test_ndof(discr, ref_sd):
 def test_trace_2d(discr, unit_sd_2d):
     trace = discr.assemble_trace_matrix(unit_sd_2d)
 
-    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1))
+    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1, 1))
     func_interp = discr.interpolate(unit_sd_2d, func)
 
     func_trace = lambda x: x[0] + x[1]
@@ -30,7 +30,7 @@ def test_trace_2d(discr, unit_sd_2d):
 def test_asym_2d(discr, unit_sd_2d):
     asym = discr.assemble_asym_matrix(unit_sd_2d)
 
-    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1))
+    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1, 1))
     func_interp = discr.interpolate(unit_sd_2d, func)
 
     func_asym = lambda x: x[0] - x[1]
@@ -83,7 +83,7 @@ def test_asym_3d(discr, unit_sd_3d):
 
 def test_assemble_mult_matrix_constant(discr, unit_sd):
     # Linear matrix function
-    func = lambda x: np.vstack([x] * pg.AMBIENT_DIM)
+    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1, 1))
     vec = discr.interpolate(unit_sd, func)
 
     # Non-trivial multiplication matrix
@@ -94,9 +94,9 @@ def test_assemble_mult_matrix_constant(discr, unit_sd):
     mult = discr.assemble_mult_matrix(unit_sd, mult_mat.ravel(), right_mult=True)
 
     def right_func(x):
-        result = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
-        result[: unit_sd.dim, : unit_sd.dim] = (
-            func(x)[: unit_sd.dim, : unit_sd.dim] @ given_matrix
+        result = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM, x.shape[-1]))
+        result[: unit_sd.dim, : unit_sd.dim] = np.einsum(
+            "ijk,jl->ilk", func(x)[: unit_sd.dim, : unit_sd.dim], given_matrix
         )
         return result
 
@@ -105,9 +105,9 @@ def test_assemble_mult_matrix_constant(discr, unit_sd):
 
     # Test the left multiplication
     def left_func(x):
-        result = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
-        result[: unit_sd.dim, : unit_sd.dim] = (
-            given_matrix @ func(x)[: unit_sd.dim, : unit_sd.dim]
+        result = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM, x.shape[-1]))
+        result[: unit_sd.dim, : unit_sd.dim] = np.einsum(
+            "ij,jkl->ikl", given_matrix, func(x)[: unit_sd.dim, : unit_sd.dim]
         )
         return result
 
@@ -119,25 +119,21 @@ def test_assemble_mult_matrix_constant(discr, unit_sd):
 
 def test_assemble_mult_matrix_heaviside(discr, unit_sd_1d):
     # Linear matrix function
-    func = lambda x: np.vstack([x] * pg.AMBIENT_DIM)
+    func = lambda x: np.tile(x, (pg.AMBIENT_DIM, 1, 1))
     linear = discr.interpolate(unit_sd_1d, func)
 
     # Heaviside
-    func_hs = lambda x: (
-        np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
-        if x[0] < np.median(unit_sd_1d.nodes[0])
-        else np.eye(pg.AMBIENT_DIM)
-    )
+    def func_hs(x):
+        hs = x[0] < np.median(unit_sd_1d.nodes[0])
+        ans = np.repeat(np.eye(pg.AMBIENT_DIM)[:, :, None], x.shape[-1], axis=2)
+
+        return ans * hs
+
     hs = discr.interpolate(unit_sd_1d, func_hs)
 
     # Known output
     def ramp(x):
-        result = np.zeros((pg.AMBIENT_DIM, pg.AMBIENT_DIM))
-        result[: unit_sd_1d.dim, : unit_sd_1d.dim] = (
-            func_hs(x)[: unit_sd_1d.dim, : unit_sd_1d.dim]
-            @ func(x)[: unit_sd_1d.dim, : unit_sd_1d.dim]
-        )
-        return result
+        return func(x) * (x[0] < np.median(unit_sd_1d.nodes[0]))
 
     known = discr.interpolate(unit_sd_1d, ramp)
 

--- a/tests/discretizations/fem/mat_l2/test_matpwquadratics.py
+++ b/tests/discretizations/fem/mat_l2/test_matpwquadratics.py
@@ -22,9 +22,9 @@ def test_trace_2d(discr, unit_sd_2d):
 
     func = lambda x: np.array(
         [
-            [x[0], x[1], 0],
-            [x[1], x[0] * x[1], 0],
-            [0, 0, 0],
+            [x[0], x[1], 0 * x[0]],
+            [x[1], x[0] * x[1], 0 * x[0]],
+            [0 * x[0], 0 * x[0], 0 * x[0]],
         ]
     )
     func_trace = lambda x: x[0] + x[0] * x[1]
@@ -45,9 +45,9 @@ def test_asym_2d(discr, unit_sd_2d):
 
     func = lambda x: np.array(
         [
-            [x[0], x[1], 0],
-            [x[0] * x[1], x[1], 0],
-            [0, 0, 0],
+            [x[0], x[1], 0 * x[0]],
+            [x[0] * x[1], x[1], 0 * x[0]],
+            [0 * x[0], 0 * x[0], 0 * x[0]],
         ]
     )
     func_asym = lambda x: x[0] * x[1] - x[1]

--- a/tests/discretizations/fem/vec_hdiv/test_vecbdm1.py
+++ b/tests/discretizations/fem/vec_hdiv/test_vecbdm1.py
@@ -24,7 +24,12 @@ def test_asym_1d(discr, unit_sd_1d):
 def test_trace_2d(discr, unit_sd_2d):
     B = discr.assemble_trace_matrix(unit_sd_2d)
 
-    fun = lambda x: np.array([[x[0] + x[1], x[0], 0], [x[1], -x[0] - x[1], 0]])
+    fun = lambda x: np.array(
+        [
+            [x[0] + x[1], x[0], 0 * x[0]],
+            [x[1], -x[0] - x[1], 0 * x[0]],
+        ]
+    )
     u = discr.interpolate(unit_sd_2d, fun)
 
     trace = B @ u

--- a/tests/discretizations/test_discretization.py
+++ b/tests/discretizations/test_discretization.py
@@ -55,3 +55,12 @@ def test_proj_to_pw_polynomials_methods_are_cached(discr):
     assert hasattr(discr.proj_to_PwPolynomials, "cache_info"), (
         f"{discr}.proj_to_PwPolynomials should be cached"
     )
+
+
+# Coverage test
+def test_unvectorized_interpolation(unit_sd_2d):
+    discr = pg.Lagrange1()
+    func = lambda _: np.arange(15)
+
+    with pytest.raises(RuntimeError):
+        discr.interpolate(unit_sd_2d, func)

--- a/tests/patch_tests/test_elasticity_mixed.py
+++ b/tests/patch_tests/test_elasticity_mixed.py
@@ -114,7 +114,7 @@ def test_elasticity_stretching(unit_sd, spaces, use_lumped):
     if unit_sd.dim == 1:
         return
 
-    u_stretch = lambda x: np.array([x[0], 0, 0])
+    u_stretch = lambda x: np.array([x[0], 0 * x[0], 0 * x[0]])
     r_stretch = lambda _: np.zeros(pg.AMBIENT_DIM) if unit_sd.dim == 3 else 0
     s_stretch = lambda _: np.array([[1.5, 0, 0], [0, 0.5, 0], [0, 0, 0.5]])
 

--- a/tests/patch_tests/test_elasticity_tpsa.py
+++ b/tests/patch_tests/test_elasticity_tpsa.py
@@ -24,7 +24,7 @@ def setup(request):
     tpsa = pg.TPSA("test")
 
     # Compute a known solution
-    displacement = lambda x: np.array([x[dim - 1], 0, 0])
+    displacement = lambda x: np.array([x[dim - 1], 0 * x[0], 0 * x[0]])
     if dim == 2:
         rotation = lambda _: 1
     else:

--- a/tests/patch_tests/test_laplacian.py
+++ b/tests/patch_tests/test_laplacian.py
@@ -31,7 +31,7 @@ def test_laplacian_dirichlet_bcs(unit_sd):
     A = discr.assemble_stiff_matrix(unit_sd, None)
 
     source_func = lambda _: 1.0
-    sol_func = lambda x: np.sum(x * (1 - x)) / (2 * unit_sd.dim)
+    sol_func = lambda x: np.sum(x * (1 - x), axis=0) / (2 * unit_sd.dim)
 
     true_sol = discr.interpolate(unit_sd, sol_func)
     f = discr.source_term(unit_sd, source_func)
@@ -60,7 +60,7 @@ def test_laplacian_mixed_bcs(unit_sd):
     A = discr.assemble_stiff_matrix(unit_sd, None)
 
     source_func = lambda _: 1.0
-    sol_func = lambda x: np.sum(x * (1 - x)) / (2 * unit_sd.dim)
+    sol_func = lambda x: np.sum(x * (1 - x), axis=0) / (2 * unit_sd.dim)
     flux_func = lambda _: -1 / (2 * unit_sd.dim)
 
     true_sol = discr.interpolate(unit_sd, sol_func)

--- a/tests/patch_tests/test_laplacian_mixed.py
+++ b/tests/patch_tests/test_laplacian_mixed.py
@@ -37,7 +37,7 @@ def test_linear_distribution(discr, unit_sd, use_lumped):
         return np.array([-1, 2, 1])
 
     def p_func(x):
-        return -x @ q_func(x)
+        return -q_func(x) @ x
 
     # assemble the saddle point problem
     if use_lumped:
@@ -73,13 +73,15 @@ def test_linear_distribution(discr, unit_sd, use_lumped):
 def test_convergence_2D(discr):
     # Provide the solution
     def q_func(x):
-        return np.array([x[1] * x[0], 2 * x[0], 0])
+        return np.array([x[1] * x[0], 2 * x[0], 0 * x[0]])
 
     def p_func(x):
         return x[0]
 
     def g_func(x):
-        return q_func(x) + np.array([1, 0, 0])
+        ans = q_func(x)
+        ans[0] += 1
+        return ans
 
     def div_func(x):
         return x[1]


### PR DESCRIPTION
The `interpolate` and `assemble_nat_bc` calls used slow for-loops. This PR speeds up the function evaluations by assuming that the given function is either vectorized or constant.

This PR closes #284 